### PR TITLE
Clarify result returned is on log scale

### DIFF
--- a/R/infiniteSum.R
+++ b/R/infiniteSum.R
@@ -1,4 +1,4 @@
-#' Returns the log of the approximation the sum of a positive discrete infinite series with a single
+#' Returns the log of an approximation of the sum of a positive discrete infinite series with a single
 #' maximum
 #'
 #' For series that pass the ratio test, the approximation is analytically


### PR DESCRIPTION
I realize the object returned implies the fact that it is the log() of the summation that is returned, but recommend it also be noted on the man page.