### PR TITLE
Fix bounding pairs approach

### DIFF
--- a/src/infiniteErrorBoundingPairs.c
+++ b/src/infiniteErrorBoundingPairs.c
@@ -42,16 +42,9 @@ long double infiniteErrorBoundingPairs_(long double logFun(long k, double *Theta
 
   do
     logFunVal[++*n] = logFun(++n0, params);
-  //while  ( (log1mL ? // if L = 0 there's a simpler convergence check
-  //            delta(logFunVal[*n] + logFunVal[*n - 1] -
-  //            Rf_logspace_sub(logFunVal[*n - 1], logFunVal[*n]),
-  //            logFunVal[*n], log1mL) >= lEps :
-  //            (logFunVal[*n - 1] - logFunVal[*n] < Rf_log1pexp(logFunVal[*n] -
-  //              lEps))) &
-  //              (*n < maxIter));
   while (((isDecreasing & 
             (logFunVal[*n] - log(-expm1(logFunVal[*n] - logFunVal[*n-1])) >=
-             lEps + LOG_2) |
+             lEps + LOG_2)) |
           (~isDecreasing &
              (logFunVal[*n] + logL - log(-expm1(logL)) >= lEps + LOG_2))) &
          (*n < maxIter));

--- a/src/infiniteErrorBoundingPairs.c
+++ b/src/infiniteErrorBoundingPairs.c
@@ -1,5 +1,6 @@
 #include "sumR_internal.h"
 #include "math.h"
+#include <stdbool.h> // for bool
 
 long double infiniteErrorBoundingPairs_(long double logFun(long k, double *Theta),
                        double *params, double logL, double eps,

--- a/src/infiniteErrorBoundingPairs.c
+++ b/src/infiniteErrorBoundingPairs.c
@@ -52,9 +52,9 @@ long double infiniteErrorBoundingPairs_(long double logFun(long k, double *Theta
 
   // Braden bounds
   KahanSum(&totalBack, expl(logFunVal[*n] - log(-expm1(logFunVal[*n] -
-    logFunVal[*n-1])) - maxA), &cb);
+    logFunVal[*n-1])) - LOG_2 - maxA), &cb);
   KahanSum(&totalBack, expl(logFunVal[*n] + logL - log(-expm1(logL)) -
-    maxA), &cb);
+    LOG_2 - maxA), &cb);
   partial_logSumExp(&logFunVal[nMax], *n - nMax - 1, maxA, &cb, 1, &totalBack);
   
   if (logFunVal != NULL) R_Free(logFunVal);


### PR DESCRIPTION
The actual version of the bounding pairs approach follows this algorithm

![image](https://github.com/user-attachments/assets/049bc160-d1f8-4810-9d72-450a5343e5a3)

But, it has problems with Braden's paper. The corrected version has been implemented. It considers two situations, the case in which the ratio of the terms is decreasing:

![image](https://github.com/user-attachments/assets/2d5ebf59-250e-47bc-92b7-6915433ea70d)

And when the ratio of the terms is crescent:

![image](https://github.com/user-attachments/assets/530850af-b040-40fd-a12a-1f72dad4f635)
